### PR TITLE
Adding a dry run flag

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
             "pytest",
             "mock",
             "coverage",
+            "six"
         ],
     },
     scripts=[

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,6 @@ setup(
             "pytest",
             "mock",
             "coverage",
-            "six"
         ],
     },
     scripts=[

--- a/tests/cmd/main_test.py
+++ b/tests/cmd/main_test.py
@@ -6,7 +6,6 @@ from __future__ import print_function
 import os.path
 
 import mock
-from six import StringIO
 
 from undebt.cmd.main import main
 from undebt.examples import method_to_function
@@ -63,12 +62,11 @@ def test_directory():
     assert _read_input_file() == method_to_function_output_contents == _read_output_file()
 
 
-def test_dry_run():
+def test_dry_run(capsys):
     args = ["undebt", "-i", method_to_function_input_path, "-p", method_to_function_path, "--verbose", "--dry-run"]
-    output = StringIO()
-    with mock.patch("sys.argv", args), mock.patch("sys.stdout", output):
+    with mock.patch("sys.argv", args):
         main()
-    assert output.getvalue() == '>>> {}\n{}'.format(method_to_function_input_path, _read_output_file())
+    assert capsys.readouterr()[0] == '>>> {}\n{}'.format(method_to_function_input_path, _read_output_file())
 
 def test_left_unchanged():
     assert _read_input_file() == method_to_function_input_contents

--- a/tests/cmd/main_test.py
+++ b/tests/cmd/main_test.py
@@ -6,6 +6,7 @@ from __future__ import print_function
 import os.path
 
 import mock
+from six import StringIO
 
 from undebt.cmd.main import main
 from undebt.examples import method_to_function
@@ -61,6 +62,13 @@ def test_directory():
         main()
     assert _read_input_file() == method_to_function_output_contents == _read_output_file()
 
+
+def test_dry_run():
+    args = ["undebt", "-i", method_to_function_input_path, "-p", method_to_function_path, "--verbose", "--dry-run"]
+    output = StringIO()
+    with mock.patch("sys.argv", args), mock.patch("sys.stdout", output):
+        main()
+    assert output.getvalue() == '>>> {}\n{}'.format(method_to_function_input_path, _read_output_file())
 
 def test_left_unchanged():
     assert _read_input_file() == method_to_function_input_contents


### PR DESCRIPTION
Adds a `--dry-run` flag that outputs all output to stdout.

## Example usage:
```shell
$ undebt -p undebt/examples/method_to_function.py  -i tests/inputs/method_to_function_input.txt --dry-run
```

## Example output:
```shell
>>> tests/inputs/method_to_function_input.txt
from function_lives_here import function
something before code pattern
@decorator([Class])
def some_function(self, abc, xyz):
    """herp the derp while also derping and herping"""
    cde = fgh(self.l)
    ijk = cde.herp(
        opq_foo=function(FOO(abc))
    )['str']
    lmn = cde.herp(
        opq_foo=function(FOO(xyz))
    )['str']
bla bla bla
    for str_data in derp_data['data']['strs']:
        if str_data['str'] == Type.HERP:
            disable(herp_foo=herp_foo, derp_foo=derp_foo)
            rst.uvw(
                CTA_BUSINESS_PLATFORM_DISABLED_LOG,
                "derp {derp_foo} herp {herp_foo}".format(
                    derp_foo=function(FOO(derp_foo)),
                    herp_foo=function(FOO(herp_foo)),
                ),
            )
something after code pattern
```
Related to issue #3 