### PR TITLE
Fix HEADER to match import statements in various forms

### DIFF
--- a/tests/pattern/python_test.py
+++ b/tests/pattern/python_test.py
@@ -124,7 +124,15 @@ from __future__ import herpaderp
 import start
 from derp import herp
 from herpderp import herp, \\
- derp
+    derp
+from foo import *
+from foo import (
+    bar,
+    baz as foobar)
+from .bar import *
+from .bar import alpha, beta
+from . import baz
+
 
 first
 second
@@ -139,9 +147,16 @@ from __future__ import herpaderp
 import start
 from derp import herp
 from herpderp import herp, \\
- derp
+    derp
+from foo import *
+from foo import (
+    bar,
+    baz as foobar)
+from .bar import *
+from .bar import alpha, beta
+from . import baz
 ''']],
         interval_list=[
-            (0, 162),
+            (0, 295),
         ],
     )

--- a/undebt/pattern/python.py
+++ b/undebt/pattern/python.py
@@ -73,5 +73,5 @@ EXPR_IND_LIST = originalTextFor(EXPR + ZeroOrMore(COMMA_IND + EXPR) + Optional(C
 HEADER = originalTextFor(START_OF_FILE + ZeroOrMore(SKIP_TO_TEXT + (
     STRING
     | pythonStyleComment
-    | Optional(Keyword("from") + DOTTED_NAME) + Keyword("import") + SkipTo(NO_BS_NL)
+    | Optional(Keyword("from") + SkipTo("import")) + Keyword("import") + Optional(PARENS) + SkipTo(NO_BS_NL)
 ) + NL))


### PR DESCRIPTION
Now it matches:
* `from . import ...`
* `from .foo import ...`
* multiline imports continued in parenthesis