### PR TITLE
Adds swift example. EXPR might not be 100% valid

### DIFF
--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -148,3 +148,19 @@ Example of:
 - using `in_string` to determine if the match location is inside of a string
 - `originalTextFor` to make grammar elements parse to the original text that matched them
 - `STRING` to match any valid string
+
+`undebt.examples.swift`
+-----------------------------------
+(`Source
+<https://github.com/Yelp/undebt/blob/master/undebt/examples/swift.py>`_)
+
+Transforms uses of `if let where` from Swift 2.2 to the updated syntax in Swift
+3.0.
+
+Example of:
+
+- using `tokens_as_dict` to assert multiple possible dictionary keys
+- `EXPR` to match a Python expression
+  - Note: It's possible that this won't match all Swift expressions; if you are
+    concerned about this, you should use an EXPR pattern that corresponds to
+    the Swift grammar.

--- a/tests/examples/swift_test.py
+++ b/tests/examples/swift_test.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from undebt.examples import swift
+from undebt.pattern.testing import assert_transform
+
+
+def test_one_liner():
+    assert_transform(
+        swift,
+        'if let x = a where x == y {',
+        ['if let x = a, x == y {'],
+    )
+
+
+def test_compound():
+    text = 'if let x = a, y = b, z = c where x == y && y != z {'
+    expected = 'if let x = a, let y = b, let z = c, x == y && y != z {'
+    assert_transform(swift, text, [expected])
+
+
+def test_expr():
+    text = 'if let x = a + 1 / b where x == -y {'
+    expected = 'if let x = a + 1 / b, x == -y {'
+    assert_transform(swift, text, [expected])

--- a/undebt/examples/swift.py
+++ b/undebt/examples/swift.py
@@ -7,6 +7,7 @@ from pyparsing import delimitedList
 from pyparsing import Keyword
 from pyparsing import Literal
 from pyparsing import SkipTo
+
 from undebt.pattern.common import NAME
 from undebt.pattern.python import EXPR
 from undebt.pattern.util import condense
@@ -33,8 +34,8 @@ def replace(tokens):
 
     def pretty_assign(assign):
         op = assign.index("=")
-        l, r = assign[:op], assign[op+1:]
+        l, r = assign[:op], assign[op + 1:]
         return "{0} = {1}".format(l, r)
 
     new_assigns = ", let ".join(map(pretty_assign, assigns))
-    return "if let " + new_assigns + ", " + cond
+    return "if let " + new_assigns + ", " + cond + "{"

--- a/undebt/examples/swift.py
+++ b/undebt/examples/swift.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from pyparsing import delimitedList
+from pyparsing import Keyword
+from pyparsing import Literal
+from pyparsing import SkipTo
+from undebt.pattern.common import NAME
+from undebt.pattern.python import EXPR
+from undebt.pattern.util import condense
+from undebt.pattern.util import tokens_as_dict
+
+
+if_ = Keyword("if")
+let = Keyword("let")
+where = Keyword("where")
+eq = Literal("=")
+
+assign = condense(NAME + eq + EXPR)
+
+grammar = (
+    if_ + let + delimitedList(assign)("let-bindings")
+    + where + SkipTo("{")("where-clause")
+)
+
+
+@tokens_as_dict(assert_keys=["let-bindings", "where-clause"])
+def replace(tokens):
+    assigns = tokens["let-bindings"]
+    cond = tokens['where-clause']
+
+    def pretty_assign(assign):
+        op = assign.index("=")
+        l, r = assign[:op], assign[op+1:]
+        return "{0} = {1}".format(l, r)
+
+    new_assigns = ", let ".join(map(pretty_assign, assigns))
+    return "if let " + new_assigns + ", " + cond


### PR DESCRIPTION
If I really cared, I would substitute EXPR with what is a valid expression
according to the swift grammar, but I think this conveys the general idea.

Address #26.

Examples:
```
(venv)~/github/undebt (add-swift-example) $ echo "if let x = a where x == y {" | undebt -p undebt/examples/swift.py
if let x = a, x == y {
(venv)~/github/undebt (add-swift-example) $ echo "if let x = a, y = b, z = c where x == y && y != z {" | undebt -p undebt/examples/swift.py
if let x = a, let y = b, let z = c, x == y && y != z {
(venv)~/github/undebt (add-swift-example) $ echo "if let x = a + 1 where x == y {" | undebt -p undebt/examples/swift.py
if let x = a + 1, x == y {
```