### PR TITLE
Allow pattern to be module

### DIFF
--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -31,7 +31,7 @@ Read it
     optional arguments:
       -h, --help            show this help message and exit
       --pattern PATH, -p PATH
-                            paths to pattern definition files/modules
+                            paths to pattern definition files or modules
       --verbose, -v
       --dry-run, -d         only print to stdout; do not overwrite files
 

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -31,7 +31,7 @@ Read it
     optional arguments:
       -h, --help            show this help message and exit
       --pattern PATH, -p PATH
-                            paths to pattern definition files
+                            paths to pattern definition files/modules
       --verbose, -v
       --dry-run, -d         only print to stdout; do not overwrite files
 

--- a/tests/cmd/main_test.py
+++ b/tests/cmd/main_test.py
@@ -56,13 +56,9 @@ def test_single_file():
 
 
 def test_loading_pattern_with_module_name():
-    # Have to do some schenanigans here to get the module name to look like it
-    # came from the project root
-    module_name = 'undebt' + (
-        method_to_function_path[:-3]
-        .split('undebt')[-1]
-        .replace('/', '.')
-    )
+    # Need full module name here
+    import undebt.examples.method_to_function
+    module_name = undebt.examples.method_to_function.__name__
     args = ["undebt", "-p", module_name, method_to_function_input_path, "--verbose"]
     with mock.patch("sys.argv", args):
         main()

--- a/tests/cmd/main_test.py
+++ b/tests/cmd/main_test.py
@@ -55,6 +55,20 @@ def test_single_file():
     assert _read_input_file() == method_to_function_output_contents == _read_output_file()
 
 
+def test_loading_pattern_with_module_name():
+    # Have to do some schenanigans here to get the module name to look like it
+    # came from the project root
+    module_name = 'undebt' + (
+        method_to_function_path[:-3]
+        .split('undebt')[-1]
+        .replace('/', '.')
+    )
+    args = ["undebt", "-p", module_name, method_to_function_input_path, "--verbose"]
+    with mock.patch("sys.argv", args):
+        main()
+    assert _read_input_file() == method_to_function_output_contents == _read_output_file()
+
+
 def test_dry_run(capsys):
     args = ["undebt", "-p", method_to_function_path, "--dry-run", method_to_function_input_path, "--verbose"]
     with mock.patch("sys.argv", args):

--- a/tests/pattern/interface_test.py
+++ b/tests/pattern/interface_test.py
@@ -4,11 +4,12 @@ from __future__ import division
 from __future__ import print_function
 
 import mock
+import pytest
 
 from undebt.examples import attribute_to_function
 from undebt.pattern.interface import get_patterns
+from undebt.pattern.interface import load_module
 from undebt.pattern.interface import module_like
-from undebt.pattern.interface import module_name_to_path
 from undebt.pattern.interface import _get_patterns
 from undebt.pattern.python import HEADER
 
@@ -56,7 +57,6 @@ def test_module_like():
     assert not module_like('bar.py')
 
 
-def test_module_name_to_path():
-    assert module_name_to_path('foo') == 'foo.py'
-    assert module_name_to_path('foo.bar') == 'foo/bar.py'
-    assert module_name_to_path('foo.bar.baz') == 'foo/bar/baz.py'
+def test_load_module_on_non_existant():
+    with pytest.raises(ImportError):
+        load_module('foo.bar.baz')

--- a/tests/pattern/interface_test.py
+++ b/tests/pattern/interface_test.py
@@ -9,7 +9,7 @@ import pytest
 from undebt.examples import attribute_to_function
 from undebt.pattern.interface import get_patterns
 from undebt.pattern.interface import load_module
-from undebt.pattern.interface import module_like
+from undebt.pattern.interface import maybe_path_to_module_name
 from undebt.pattern.interface import _get_patterns
 from undebt.pattern.python import HEADER
 
@@ -50,11 +50,13 @@ def test_get_patterns():
     assert grammar2 is HEADER
 
 
-def test_module_like():
-    assert module_like('foo.bar')
-    assert module_like('foo.bar.baz')
-    assert not module_like('foo/bar.py')
-    assert not module_like('bar.py')
+def test_maybe_path_to_module_name():
+    assert 'foo.bar' == maybe_path_to_module_name('foo.bar')
+    assert 'foo.bar' == maybe_path_to_module_name('foo/bar.py')
+    assert 'foo.bar' == maybe_path_to_module_name('foo/bar')
+
+    with pytest.raises(ValueError):
+        maybe_path_to_module_name('../relative/path.py')
 
 
 def test_load_module_on_non_existant():

--- a/tests/pattern/interface_test.py
+++ b/tests/pattern/interface_test.py
@@ -8,6 +8,7 @@ import mock
 from undebt.examples import attribute_to_function
 from undebt.pattern.interface import get_patterns
 from undebt.pattern.interface import module_like
+from undebt.pattern.interface import module_name_to_path
 from undebt.pattern.interface import _get_patterns
 from undebt.pattern.python import HEADER
 
@@ -53,3 +54,9 @@ def test_module_like():
     assert module_like('foo.bar.baz')
     assert not module_like('foo/bar.py')
     assert not module_like('bar.py')
+
+
+def test_module_name_to_path():
+    assert module_name_to_path('foo') == 'foo.py'
+    assert module_name_to_path('foo.bar') == 'foo/bar.py'
+    assert module_name_to_path('foo.bar.baz') == 'foo/bar/baz.py'

--- a/tests/pattern/interface_test.py
+++ b/tests/pattern/interface_test.py
@@ -5,7 +5,11 @@ from __future__ import print_function
 
 import mock
 
+from undebt.examples import attribute_to_function
+from undebt.pattern.interface import get_patterns
+from undebt.pattern.interface import module_like
 from undebt.pattern.interface import _get_patterns
+from undebt.pattern.python import HEADER
 
 
 def test_get_patterns_module_with_patterns():
@@ -32,3 +36,20 @@ def test_get_patterns_module_bad_format(mock_exit, mock_log):
 
     assert mock_log.call_count == 1
     mock_exit.assert_called_once_with(1)
+
+
+def test_get_patterns():
+    # patterns = [[(grammar, replace), (HEADER, extra_replace)]]
+    patterns = get_patterns(attribute_to_function)
+    [patternset] = patterns
+    [pattern1, pattern2] = patternset
+    (grammar1, replace1) = pattern1
+    (grammar2, replace2) = pattern2
+    assert grammar2 is HEADER
+
+
+def test_module_like():
+    assert module_like('foo.bar')
+    assert module_like('foo.bar.baz')
+    assert not module_like('foo/bar.py')
+    assert not module_like('bar.py')

--- a/undebt/cmd/main.py
+++ b/undebt/cmd/main.py
@@ -4,7 +4,6 @@ from __future__ import division
 from __future__ import print_function
 
 import argparse
-import os
 import sys
 import traceback
 

--- a/undebt/cmd/main.py
+++ b/undebt/cmd/main.py
@@ -60,7 +60,7 @@ def _handle_arguments():
     )
     parser.add_argument(
         '--pattern', '-p', metavar='PATH', action='append', required=True,
-        help='paths to pattern definition files',
+        help='paths to pattern definition files/modules',
     )
     parser.add_argument(
         '--verbose', '-v', action='store_true', default=False,

--- a/undebt/cmd/main.py
+++ b/undebt/cmd/main.py
@@ -60,7 +60,7 @@ def _handle_arguments():
     )
     parser.add_argument(
         '--pattern', '-p', metavar='PATH', action='append', required=True,
-        help='paths to pattern definition files/modules',
+        help='paths to pattern definition files or modules',
     )
     parser.add_argument(
         '--verbose', '-v', action='store_true', default=False,

--- a/undebt/pattern/interface.py
+++ b/undebt/pattern/interface.py
@@ -80,7 +80,9 @@ def load_module(path):
 def maybe_path_to_module_name(maybe_path):
     relpath = os.path.relpath(maybe_path)
     if relpath.startswith('..'):
-        raise ValueError("Relative imports not allowed: {}", relpath)
+        raise ValueError(
+            "Relative file paths not allowed: {}".format(relpath),
+        )
     name = relpath.replace(os.sep, '.')
     name_parts = name.split('.')
     if name_parts[-1] == 'py':

--- a/undebt/pattern/interface.py
+++ b/undebt/pattern/interface.py
@@ -15,11 +15,6 @@ from undebt.pattern.util import attach
 from undebt.pattern.util import tokens_as_list
 
 
-# _module_re is not _strictly_ correct, but we do a quick check for strings
-# ending in .py before running the regex.
-_module_re = re.compile(r'^\w+(\.\w+)*$')
-
-
 # required at the beginning of a string to be able to properly parse it
 #  " " is necessary to make START_OF_FILE work properly
 PARSING_PREFIX = " "
@@ -84,6 +79,11 @@ def load_module(path):
         path = module_name_to_path(path)
     pattern_name = os.path.splitext(os.path.basename(path))[0]
     return imp.load_source(pattern_name, path)
+
+
+# _module_re is not _strictly_ correct, but we do a quick check for strings
+# ending in .py before running the regex.
+_module_re = re.compile(r'^\w+(\.\w+)*$')
 
 
 def module_like(path):

--- a/undebt/pattern/interface.py
+++ b/undebt/pattern/interface.py
@@ -4,7 +4,6 @@ from __future__ import division
 from __future__ import print_function
 
 import imp
-import importlib
 import os
 import re
 import sys
@@ -77,20 +76,10 @@ def patterns_from_files(pattern_files):
 def load_module(path):
     """Loads a module from its path."""
     if module_like(path):
-        return _load_module(path)
+        return __import__(path, fromlist=[''])
 
     pattern_name = os.path.splitext(os.path.basename(path))[0]
     return imp.load_source(pattern_name, path)
-
-
-def _load_module(full_name):
-    try:
-        return importlib.import_module(full_name)
-    except ImportError as e:
-        raise e
-    finally:
-        # Unshim path
-        sys.path = sys.path[1:]
 
 
 # _module_re is not _strictly_ correct, but we do a quick check for strings

--- a/undebt/pattern/interface.py
+++ b/undebt/pattern/interface.py
@@ -5,6 +5,7 @@ from __future__ import print_function
 
 import imp
 import os
+import re
 import sys
 
 from pyparsing import _trim_arity
@@ -12,6 +13,11 @@ from pyparsing import _trim_arity
 from undebt.cmd.logger import log
 from undebt.pattern.util import attach
 from undebt.pattern.util import tokens_as_list
+
+
+# _module_re is not _strictly_ correct, but we do a quick check for strings
+# ending in .py before running the regex.
+_module_re = re.compile(r'^\w+(\.\w+)*$')
 
 
 # required at the beginning of a string to be able to properly parse it
@@ -76,6 +82,13 @@ def load_module(path):
     """Loads a module from its path."""
     pattern_name = os.path.splitext(os.path.basename(path))[0]
     return imp.load_source(pattern_name, path)
+
+
+def module_like(path):
+    if path.endswith('.py'):
+        return False
+
+    return bool(_module_re.match(path))
 
 
 def create_find_and_replace(grammar, replace):

--- a/undebt/pattern/interface.py
+++ b/undebt/pattern/interface.py
@@ -4,6 +4,7 @@ from __future__ import division
 from __future__ import print_function
 
 import imp
+import importlib
 import os
 import re
 import sys
@@ -84,18 +85,7 @@ def load_module(path):
 
 def _load_module(full_name):
     try:
-        sys.path = [os.getcwd()] + sys.path
-        (mod, path) = (None, None)
-        for name in full_name.split('.'):
-            # path=None defaults to sys.path (along with some other special
-            # places), which is why we shim it to include the cwd.
-            (f, p, d) = imp.find_module(name, path)
-            mod = imp.load_module(name, f, p, d)
-            # If `mod` is the final submodule, it will not have a __path__
-            # attribute.
-            path = getattr(mod, '__path__', None)
-
-        return mod
+        return importlib.import_module(full_name)
     except ImportError as e:
         raise e
     finally:

--- a/undebt/pattern/interface.py
+++ b/undebt/pattern/interface.py
@@ -80,6 +80,8 @@ def patterns_from_files(pattern_files):
 
 def load_module(path):
     """Loads a module from its path."""
+    if module_like(path):
+        path = module_name_to_path(path)
     pattern_name = os.path.splitext(os.path.basename(path))[0]
     return imp.load_source(pattern_name, path)
 
@@ -89,6 +91,10 @@ def module_like(path):
         return False
 
     return bool(_module_re.match(path))
+
+
+def module_name_to_path(module_name):
+    return module_name.replace('.', '/') + '.py'
 
 
 def create_find_and_replace(grammar, replace):


### PR DESCRIPTION
Refs #40. Based on #37.

Example use:
```bash
(venv) ~/d/undebt(allow-pattern-to-be-module)> python setup.py install >/dev/null                                [9 seconds ago]
zip_safe flag not set; analyzing archive contents...
(venv) ~/d/undebt(allow-pattern-to-be-module)>
undebt -p undebt.examples.method_to_function ./tests/inputs/method_to_function_input.txt
(venv) ~/d/undebt(allow-pattern-to-be-module - 4+4-)> git d                                                     [29 seconds ago]
diff --git a/tests/inputs/method_to_function_input.txt b/tests/inputs/method_to_function_input.txt
index 641f2bb..7681c63 100644
--- a/tests/inputs/method_to_function_input.txt
+++ b/tests/inputs/method_to_function_input.txt
@@ -5,10 +5,10 @@ def some_function(self, abc, xyz):
     """herp the derp while also derping and herping"""
     cde = fgh(self.l)
     ijk = cde.herp(
-        opq_foo=FOO(abc).method()
+        opq_foo=function(FOO(abc))
     )['str']
     lmn = cde.herp(
-        opq_foo=FOO(xyz).method()
+        opq_foo=function(FOO(xyz))
     )['str']
 bla bla bla
     for str_data in derp_data['data']['strs']:
@@ -17,8 +17,8 @@ bla bla bla
             rst.uvw(
                 CTA_BUSINESS_PLATFORM_DISABLED_LOG,
                 "derp {derp_foo} herp {herp_foo}".format(
-                    derp_foo=FOO(derp_foo).method(),
-                    herp_foo=FOO(herp_foo).method(),
+                    derp_foo=function(FOO(derp_foo)),
+                    herp_foo=function(FOO(herp_foo)),
                 ),
             )
 something after code pattern
(venv) ~/d/undebt(allow-pattern-to-be-module - 4+4-)>                                                           [32 seconds ago]
```