### PR TITLE
Refactors _file_processor class to a function

### DIFF
--- a/undebt/__init__.py
+++ b/undebt/__init__.py
@@ -6,4 +6,4 @@ from __future__ import print_function
 
 # this should be the only place where the version is kept, if you
 # need to know the version somewhere else just import it from here
-__version__ = "0.6.0"
+__version__ = "0.6.1"


### PR DESCRIPTION
Resolves #53

I also took advantage of the opportunity to clean up some of the `pep8` complains in tests/cmd/main_test.py.

Two things:
1. We now have `undebt.cmd.main.process` and `undebt.cmd.logic.process`. We may want to merge these two methods.
1. I'm not sure how valuable all of these tests in tests/cmd/main_test.py are now, since a few of them were verifying behavior of `_file_processor` objects.