### PR TITLE
Allows ANY_CHAR to match Unicode characters

### DIFF
--- a/undebt/pattern/common.py
+++ b/undebt/pattern/common.py
@@ -24,7 +24,7 @@ from undebt.pattern.util import condense
 from undebt.pattern.util import fixto
 
 
-ANY_CHAR = Regex(r".", re.DOTALL)
+ANY_CHAR = Regex(r".", re.DOTALL | re.U)
 
 
 START_OF_FILE = StringStart().suppress()


### PR DESCRIPTION
The name is `ANY_CHAR`, so it should match any char--and Unicode chars are chars too!